### PR TITLE
feat: add live capture of video using cv2 and html canvas 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,6 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "fastapi[standard]>=0.116.1",
+    "uuid>=1.30",
+    "uvicorn>=0.35.0",
 ]

--- a/src/dummy_file.txt
+++ b/src/dummy_file.txt
@@ -1,1 +1,0 @@
-# dummy file for creating the folder.

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Live Camera Stream to FastAPI</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      padding: 20px;
+      text-align: center;
+    }
+    video {
+      border: 2px solid #333;
+      border-radius: 8px;
+      width: 480px;
+      height: 360px;
+    }
+    #status {
+      margin-top: 15px;
+      color: green;
+    }
+  </style>
+</head>
+<body>
+  <h1>Camera Stream → FastAPI</h1>
+  <video id="video" autoplay playsinline></video>
+  <div id="status">Initializing...</div>
+
+  <script>
+    const video = document.getElementById("video");
+    const status = document.getElementById("status");
+
+    async function startCamera() {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        video.srcObject = stream;
+        status.textContent = "Camera started. Streaming to server...";
+        startStreaming();
+      } catch (err) {
+        status.textContent = "Error accessing camera: " + err;
+      }
+    }
+
+    function startStreaming() {
+      const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext("2d");
+      canvas.width = 480;
+      canvas.height = 360;
+
+      async function sendFrame() {
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+        canvas.toBlob(async (blob) => {
+          if (!blob) return;
+
+          try {
+            await fetch("http://localhost:8000/get_video", {
+              method: "POST",
+              body: blob,
+              headers: { "Content-Type": "application/octet-stream" }
+            });
+          } catch (err) {
+            console.error("Error sending frame:", err);
+          }
+        }, "image/jpeg", 0.7); // JPEG frame
+
+        requestAnimationFrame(sendFrame); // keep sending frames
+      }
+
+      sendFrame();
+    }
+
+    startCamera();
+  </script>
+</body>
+</html>
+

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+import uvicorn
+from server.routers import video
+
+app = FastAPI()
+
+# include video router
+app.include_router(video.router)
+
+if __name__ == "__main__":
+    uvicorn.run("server.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/src/server/routers/__init__.py
+++ b/src/server/routers/__init__.py
@@ -1,0 +1,1 @@
+from . import video

--- a/src/server/routers/video.py
+++ b/src/server/routers/video.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, Request
+from queue import Queue
+import uuid
+
+router = APIRouter()
+
+# In-memory frame queue
+frame_queue = Queue()
+
+
+@router.post("/get_video")
+async def get_video(request: Request):
+    """
+    Receives a JPEG frame from the frontend camera and pushes it into a queue.
+    """
+    frame_bytes = await request.body()
+    frame_id = str(uuid.uuid4())
+
+    frame_queue.put({
+        "id": frame_id,
+        "bytes": frame_bytes
+    })
+
+    return {"status": "success", "frame_id": frame_id, "queue_size": frame_queue.qsize()}
+
+
+@router.get("/next_frame")
+def next_frame():
+    """
+    Retrieves the next frame (for debugging/processing).
+    """
+    if frame_queue.empty():
+        return {"status": "empty"}
+    
+    frame = frame_queue.get()
+    return {
+        "status": "success",
+        "frame_id": frame["id"],
+        "frame_size": len(frame["bytes"])
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -358,10 +358,16 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
+    { name = "uuid" },
+    { name = "uvicorn" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "fastapi", extras = ["standard"], specifier = ">=0.116.1" }]
+requires-dist = [
+    { name = "fastapi", extras = ["standard"], specifier = ">=0.116.1" },
+    { name = "uuid", specifier = ">=1.30" },
+    { name = "uvicorn", specifier = ">=0.35.0" },
+]
 
 [[package]]
 name = "rich"
@@ -509,6 +515,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
 ]
+
+[[package]]
+name = "uuid"
+version = "1.30"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/63/f42f5aa951ebf2c8dac81f77a8edcc1c218640a2a35a03b9ff2d4aa64c3d/uuid-1.30.tar.gz", hash = "sha256:1f87cc004ac5120466f36c5beae48b4c48cc411968eed0eaecd3da82aa96193f", size = 5811, upload-time = "2007-05-26T11:13:24Z" }
 
 [[package]]
 name = "uvicorn"


### PR DESCRIPTION
this introduces the following changes:

1. adds the video processing inside routers/video.py to handle live capture of videos 
and pushes in into the queue.